### PR TITLE
Add AUR instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ will work on x86_64 and i686.
 
 See the [repository README](https://debian.nabijaczleweli.xyz/README) for more information.
 
+#### From AUR
+
+`termimage` can be installed from available [AUR packages](https://aur.archlinux.org/packages/?O=0&SeB=b&K=termimage&outdated=&SB=n&SO=a&PP=50&do_Search=Go) using an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers). For example,
+
+```sh
+yay -S termimage
+```
+
+If you prefer, you can clone the [AUR packages](https://aur.archlinux.org/packages/?O=0&SeB=b&K=termimage&outdated=&SB=n&SO=a&PP=50&do_Search=Go) and then compile them with [makepkg](https://wiki.archlinux.org/index.php/Makepkg). For example,
+
+```sh
+git clone https://aur.archlinux.org/termimage.git && cd termimage && makepkg -si
+```
+
 #### From pre-built executables
 
 Alternatively, have a glance over at the [releases page](https://github.com/nabijaczleweli/termimage/releases), which should host Windows and Linux x86_64 binaries.


### PR DESCRIPTION
Hi,
I'm an [Arch Linux](https://aur.archlinux.org) package [maintainer](https://github.com/orhun/PKGBUILDs). I'm submitting this PR to let you know that I created the following packages for the installation of `termimage` on Arch Linux and other distributions that support installing packages from [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository):

* [termimage](https://aur.archlinux.org/packages/termimage/) (builds from source)
* [termimage-bin](https://aur.archlinux.org/packages/termimage-bin/) (latest binary)
* [termimage-git](https://aur.archlinux.org/packages/termimage-git/) (VCS/development package)

I also updated README.md about installation from AUR. (26b5ab9)

BR,
orhun.