### PR TITLE
feat: bump image (no changes)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = ["*.enc"]
 
 [dependencies]
 term_size = "0.3"
-image = "0.24"
+image = "0.25"
 clap = "2.33"
 
 [target.'cfg(target_os = "windows")'.dependencies.winapi]


### PR DESCRIPTION
Update the `image` crate, adding support for a bunch of formats, and helping out consumers of the library, who are currently forced to use old `image`.

No code changes are necessary to get the tests to pass.